### PR TITLE
Make training laser have `WEIGHT_CLASS_NORMAL`

### DIFF
--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -30,5 +30,8 @@
 /obj/item/gun/energy/laser/tag
 	w_class = WEIGHT_CLASS_NORMAL
 
+/obj/item/gun/energy/laser/practice
+	w_class = WEIGHT_CLASS_NORMAL
+
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
This pull request merges upstream/master. Resolve possible conflicts manually and make sure all the changes are applied correctly.

> [!IMPORTANT]
> Configuration Change:
> www.github.com/ParadiseSS13/Paradise/pull/27636

> [!NOTE]
> Requires Wiki Update:
> www.github.com/ParadiseSS13/Paradise/pull/27438
> www.github.com/ParadiseSS13/Paradise/pull/27781
> www.github.com/ParadiseSS13/Paradise/pull/27861
> www.github.com/ParadiseSS13/Paradise/pull/27831
> www.github.com/ParadiseSS13/Paradise/pull/27670
> www.github.com/ParadiseSS13/Paradise/pull/27768

## Changelog
:cl: ParadiseSS13
fix: Vtec стал немного разумнее.   <!-- Vtec is a bit more sane now (www.github.com/ParadiseSS13/Paradise/pull/27819) -->
fix: Исправлена уязвимость, связанная с уровнями исследований и странными объектами.   <!-- Fixed an exploit with research levels and strange objects. (www.github.com/ParadiseSS13/Paradise/pull/27836) -->
add: Добавлены события с блюспейс-харвестерами.   <!-- Added bluespace harvester events (www.github.com/ParadiseSS13/Paradise/pull/27438) -->
add: Автоматическая генерация наград блюспейс-харвестерами на интервалах времени.   <!-- Bluespace harvester auto-spawning rewards at intervals (www.github.com/ParadiseSS13/Paradise/pull/27438) -->
tweak: Сильно изменён пул наград блюспейс-харвестеров.   <!-- Adjusted the bluespace harvester reward pool heavily (www.github.com/ParadiseSS13/Paradise/pull/27438) -->
tweak: Углерод в Тауэркапах был заменен на растительное волокно.   <!-- Replaces Carbon in Towercaps with Plant-matter (www.github.com/ParadiseSS13/Paradise/pull/27754) -->
fix: Ввод текста в TGUI больше не будет автоматически перемещать курсор в конец текста при редактировании.   <!-- TGUI text input will no longer constantly jump you to the end while you're trying to edit earlier in what you typed. (www.github.com/ParadiseSS13/Paradise/pull/27827) -->
fix: Снижена вероятность событий с блюспейс-харвестерами до более ожидаемого уровня.   <!-- Lowered probabilty of BSH events to more expected levels (www.github.com/ParadiseSS13/Paradise/pull/27852) -->
fix: Очистка блюспейс-харвестера теперь действительно очищает его.   <!-- Cleaning a BSH actually cleans it (www.github.com/ParadiseSS13/Paradise/pull/27852) -->
tweak: Торговцы USSP теперь могут говорить на своем родном языке.   <!-- USSP traders can speak their home language (www.github.com/ParadiseSS13/Paradise/pull/27747) -->
imageadd: Обновлены спрайты северных и южных PTL.   <!-- Resprited the north and south PTL (www.github.com/ParadiseSS13/Paradise/pull/27791) -->
fix: Теперь PTL не принимает значения выхода меньше 1.   <!-- The PTL no longer accepts output amounts of <1 (www.github.com/ParadiseSS13/Paradise/pull/27791) -->
tweak: Консоль шахтерского челнока стала более информативной.   <!-- Made the mining shuttle console more informative. (www.github.com/ParadiseSS13/Paradise/pull/27667) -->
tweak: Клавиша для удаления аксессуара отображается только при наличии прикрепленного аксессуара.   <!-- remove accessory keybind only shows when there's an attached accessory (www.github.com/ParadiseSS13/Paradise/pull/27687) -->
tweak: Выделены жирным шрифтом описания привязок клавиш, связанных с одеждой.   <!-- bolded all clothing related keybinding descriptions (www.github.com/ParadiseSS13/Paradise/pull/27687) -->
tweak: Шлем тактического экзокостюма теперь указывает, что его нужно держать, чтобы изменить внешний вид.   <!-- tactical envirosuit helmet now says it needs to be held in order to be reskinned (www.github.com/ParadiseSS13/Paradise/pull/27687) -->
fix: Шлемы экзокостюмов теперь показывают, как удалить аксессуар.   <!-- envirosuit helmets will now tell how to remove an accessory (www.github.com/ParadiseSS13/Paradise/pull/27687) -->
fix: Сыр, полученный путем проливания его на землю, теперь снова содержит питательные вещества.   <!-- cheese gained from pouring cheese on the ground now has nutrients again (www.github.com/ParadiseSS13/Paradise/pull/27774) -->
fix: Уменьшена продолжительность дыма от дымовых гранат с 120 до 32 секунд (изменение добавлено по ошибке).   <!-- Sets smoke from smoke grenades to last 32 seconds instead of 120. This change was done by accident. (www.github.com/ParadiseSS13/Paradise/pull/27787) -->
fix: Дым от дымовых гранат снова распространяется случайным образом.   <!-- Smoke from smoke grenades spread around in random directions again. (www.github.com/ParadiseSS13/Paradise/pull/27787) -->
tweak: Энергетический био-чип теперь одинаково реагирует на намерения помощи и захвата, а также на намерения удара и защиты, вместо того чтобы ничего не делать.   <!-- The power Bio-Chip will treat help and disarm intent the same, as with grab and harm. Rather than just not doing anything (www.github.com/ParadiseSS13/Paradise/pull/27781) -->
fix: Исправлено требование отключения и повторного включения био-чипа для его работы. Теперь достаточно просто включить его.   <!-- Fixed needing to turn off and on the power Bio-Chip to make it work. You now just need to turn it on. (www.github.com/ParadiseSS13/Paradise/pull/27781) -->
fix: Исправлены боковые спрайты аварийных шкафчиков.   <!-- Emergency locker side sprites fixed. (www.github.com/ParadiseSS13/Paradise/pull/27776) -->
tweak: Обновлены и слегка перерисованы спрайты берета НКТ (носимые персонажем).   <!-- Refitted and slightly reshaded the onmob sprite for the NCT beret. (www.github.com/ParadiseSS13/Paradise/pull/27778) -->
imageadd: Добавлены спрайты берета НКТ для киданов.   <!-- Added kidan onmob sprites for the NCT beret. (www.github.com/ParadiseSS13/Paradise/pull/27778) -->
add: Галлюцинация с прыжком ксеноморфа снова активирована.   <!-- The xeno pounce hallucination has been enabled again (www.github.com/ParadiseSS13/Paradise/pull/27656) -->
tweak: Увеличены задержки при снятии и надевании через меню раздевания.   <!-- Increased strip and put on delays for the strip menu (www.github.com/ParadiseSS13/Paradise/pull/27773) -->
add: Шефы теперь могут сразу высыпать содержимое целых сумок или подносов в кухонные приборы. Работает только с теми контейнерами, которые можно быстро опустошить на пол, включая подносы и мешки для растений, но не рюкзаки.   <!-- Chefs can now dump entire bags/trays into kitchen appliances. Only works with bags that can be quick-emptied onto the floor, including serving trays and plant bags, but not backpacks. (www.github.com/ParadiseSS13/Paradise/pull/27818) -->
spellcheck: Удалён лишний артикль "the" при добавлении неподходящих реагентов в микроволновку.   <!-- Removed an errant "the" when trying to add unsuitable reagents to a microwave. (www.github.com/ParadiseSS13/Paradise/pull/27818) -->
fix: При сборе урожая из гидропонной грядки с помощью мешка для растений продукты, не относящиеся к еде (например, брёвна), теперь попадают в мешок.   <!-- When harvesting a hydroponics tray with a plant bag, non-food produce (e.g. logs) now goes into the plant bag. (www.github.com/ParadiseSS13/Paradise/pull/27789) -->
fix: При сборе урожая из гидропонной грядки с мешком для растений вы больше не подбираете остальной урожай с пола.   <!-- When harvesting a hydroponics tray with a plant bag, you no longer pick up other produce off the floor. (www.github.com/ParadiseSS13/Paradise/pull/27789) -->
add: Добавлены деловые костюмы в меню лодаута.   <!-- Added business suits to the loadout menu (www.github.com/ParadiseSS13/Paradise/pull/27758) -->
add: Новое космическое руинство: Заброшенный Монастырь Механизмов.   <!-- New space ruin: the Abandoned Clockwork Monastery. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
add: Новый противник-конструкт: Механизм-Мародёр.   <!-- New enemy construct: the Clockwork Marauder. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
add: Все механические компоненты добавлены и представлены в Монастыре в мастерской и феретории.   <!-- All clockwork components have been added and are featured at the Monastery in the workshop and feretory. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
soundadd: Добавлен anima_fragment_attack.ogg для использования Механизмом-Мародёром.   <!-- Added anima_fragment_attack.ogg for use by the Clockwork Marauder. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
soundadd: Добавлены reebe_ambiance_1.ogg, reebe_ambiance_2.ogg и reebe_ambiance_3.ogg для фоновых звуков Монастыря.   <!-- Added reebe_ambiance_1.ogg, reebe_ambiance_2.ogg, and reebe_ambiance_3.ogg for Monastery ambient sounds. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
tweak: Осветительные приборы механики теперь излучают слегка оранжевый свет, оптимизированный для локаций из латуни.   <!-- Clockwork light fixtures now have a slight orange quality to their light, optimized for brass locations. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
add: Новый комплект постельного белья: Ратварианский Комплект.   <!-- New bedsheet: the Ratvarian Bedsheet. (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
imageadd: Латунные инструменты теперь имеют иконки на поясе.   <!-- The brass tools now have belt icons! (www.github.com/ParadiseSS13/Paradise/pull/27636) -->
tweak: Хранилища (включая кухонные подносы) теперь разбросают своё содержимое рядом с курсором, если их бросить на стол или плитку.   <!-- Storage bags (including the chef's trays) now scatter their contents near the cursor when you drag-and-drop them onto a table or tile. (www.github.com/ParadiseSS13/Paradise/pull/27790) -->
imageadd: Новые спрайты для камер (в руках) от Mickyan.   <!-- New camera inhands by Mickyan. (www.github.com/ParadiseSS13/Paradise/pull/27841) -->
del: Скорость запуска сервера снижена приблизительно на 10 секунд.   <!-- About 10 seconds of server start time. (www.github.com/ParadiseSS13/Paradise/pull/27862) -->
spellcheck: Заменен подчеркивающий символ на пробел в названии ключевого колеса авангарда.   <!-- Replaced an underscore with a space in the vanguard cogwheel's name. (www.github.com/ParadiseSS13/Paradise/pull/27864) -->
fix: КПБ теперь исцеляются при использовании предмета "Его Милость".   <!-- IPCs heal while using His Grace (www.github.com/ParadiseSS13/Paradise/pull/27865) -->
fix: Исправлено поведение скинов киборгов, которые ранее не могли носить шляпы после их удаления.   <!-- Fixed cyborg skins that used to have hats, not being able to wear hats after they got removed. (www.github.com/ParadiseSS13/Paradise/pull/27875) -->
fix: Исправлены шкафчики камер содержания на Дельта-станции.   <!-- Fixes Deltastation's brig lockers. (www.github.com/ParadiseSS13/Paradise/pull/27877) -->
fix: Закрыта огромная дыра на всех челноках. Теперь они снова будут удерживать воздух.   <!-- Patched the massive hole in all shuttles. They'll hold air again. (www.github.com/ParadiseSS13/Paradise/pull/27884) -->
fix: Исправлены точки спавна магистрата и АВД на Керберосе.   <!-- Fixes magistrate and IAA spawn on kerberos (www.github.com/ParadiseSS13/Paradise/pull/27800) -->
fix: Цели, добавленные администраторами, больше не будут случайно отображаться как "Свободная цель".   <!-- Admin-added custom objectives will no longer accidentally end up as "Free objective" sometimes. (www.github.com/ParadiseSS13/Paradise/pull/27856) -->
tweak: Кнопка случайного выбора тела в меню создания персонажа стала немного понятнее.   <!-- The body randomize button is now a bit more clear in what it does (www.github.com/ParadiseSS13/Paradise/pull/27879) -->
fix: Ещё больше дыр в челноках исправлено. Теперь мы на 97% уверены, что они герметичны.   <!-- Even more holes in the shuttles have been fixed. We're 97% certain they're airtight now. (www.github.com/ParadiseSS13/Paradise/pull/27889) -->
add: Солнечные панели на Мета-станции теперь изначально установлены.   <!-- Solar Panels on Metastation are now built by default (www.github.com/ParadiseSS13/Paradise/pull/27660) -->
del: Солнечные ящики убраны с Мета-станции.   <!-- Removed solar crates from Metastation (www.github.com/ParadiseSS13/Paradise/pull/27660) -->
tweak: Описание модуля замка с пружиной уточнено для лучшего понимания способа активации (дымом).   <!-- Clarified the spring lock module description to better specify its activation method (smoke). (www.github.com/ParadiseSS13/Paradise/pull/27861) -->
fix: Исправлен цвет двери ХОСа и добавлен отсутствующий считыватель карты.   <!-- Fixed HoS' door color and lack of key card authenticator (www.github.com/ParadiseSS13/Paradise/pull/27849) -->
fix: Консоли камер теперь показывают правильное изображение даже при первом использовании.   <!-- Camera consoles now show correct image even if viewed first time (www.github.com/ParadiseSS13/Paradise/pull/27753) -->
tweak: ГОРЯЧЕЕ ПРЕДЛОЖЕНИЕ НА ЧУЖИЕ СПЛАВЫ: СКИДКА 50%!   <!-- HOT NEW DEAL ON ALIEN ALLOYS: 50% OFF! (www.github.com/ParadiseSS13/Paradise/pull/27831) -->
tweak: Инжекторы теперь ведут себя так же, как вентиляционные отверстия и очистители, в плане взаимодействия с другими объектами при установке.   <!-- Make injectors behave the same as vents and scrubbers in terms of interference with placement of other pipes and devices (www.github.com/ParadiseSS13/Paradise/pull/27835) -->
tweak: Шахтерский борг теперь имеет ту же способность к модификации PKA, что и стандартный PKA.   <!-- Gave the Mining Borg PKA the same mod capacity as a standard PKA (www.github.com/ParadiseSS13/Paradise/pull/27670) -->
tweak: Биозащитные костюмы службы безопасности теперь имеют менее значительное замедление.   <!-- Security Biosuits now have a less severe slowdown (www.github.com/ParadiseSS13/Paradise/pull/27768) -->
add: Администраторы теперь могут легче делать объекты "говорящими" и добавлять им эмоции.   <!-- Admins can now make stuff talk more easily, and make stuff use emotes, too. (www.github.com/ParadiseSS13/Paradise/pull/27826) -->
fix: Луч разложения Легиона больше не наносит в 50 раз больше ожидаемого урона.   <!-- Legion disintegration beams should no longer cause 50x their expected damage. (www.github.com/ParadiseSS13/Paradise/pull/27886) -->
fix: Исправлено событие СМ C-3.   <!-- Fixed SM event C-3 (www.github.com/ParadiseSS13/Paradise/pull/27924) -->
fix: Предметы больше не будут загораться, если их перемещать из руки в руку или класть/доставать из сумок/коробок/ремней над лавой.   <!-- Items will, actually, no longer catch on fire when swapping them between hands, or inserting into or removing them from bags/boxes/belts etc. over lava. (www.github.com/ParadiseSS13/Paradise/pull/27720) -->
fix: Предметы больше не будут падать в бездны по тем же причинам.   <!-- Items will, actually, no longer fall into chasms when swapping them between hands, or inserting into or removing them from bags/boxes/belts etc. over chasms. (www.github.com/ParadiseSS13/Paradise/pull/27720) -->
fix: Зависшие под воздействием ЭМИ мозги больше не будут пытаться использовать эмоции.   <!-- EMP'd brains will no longer try to emote (www.github.com/ParadiseSS13/Paradise/pull/27901) -->
fix: Дзюдо-пояса теперь издают правильные звуки при снятии и выделяются при наведении в руках после снятия с ременного слота.   <!-- Judo belts make the proper sounds when unequipped and are properly highlighted when hovering over them in hands after being unequipped from the belt slot. (www.github.com/ParadiseSS13/Paradise/pull/27908) -->
fix: Исправлены заброшенные шкафчики службы безопасности на Изумрудной станции.   <!-- Fixed emeraldstation abandoned sec lockers (www.github.com/ParadiseSS13/Paradise/pull/27893) -->
fix: Исправлен доступ к бронированным дверям арсенала.   <!-- Fixed armory windoor access (www.github.com/ParadiseSS13/Paradise/pull/27893) -->
fix: Добавлена пожарная сигнализация в ксенобиологию.   <!-- Gave xenobiology a proper fire alarm (www.github.com/ParadiseSS13/Paradise/pull/27893) -->
tweak: Обновлены спрайты грязных полов.   <!-- Resprites Grimey Flooring (www.github.com/ParadiseSS13/Paradise/pull/27882) -->
tweak: Обновлены спрайты экранов развлечений.   <!-- Resprites Entertainment Screens (www.github.com/ParadiseSS13/Paradise/pull/27860) -->
tweak: Обновлены спрайты удобных стульев.   <!-- Resprited Comfy Chairs (www.github.com/ParadiseSS13/Paradise/pull/27846) -->
tweak: Обновлены спрайты деревянных столов и полов.   <!-- Resprites Wood Tables and Wood Flooring (www.github.com/ParadiseSS13/Paradise/pull/27829) -->
imageadd: Обновлены спрайты большинства дисков.   <!-- Resprited most disks (www.github.com/ParadiseSS13/Paradise/pull/27804) -->
tweak: Диски теперь доступны в большем количестве цветов.   <!-- Disks are available in more colors (www.github.com/ParadiseSS13/Paradise/pull/27804) -->
tweak: Теперь вы можете попытаться вставить больше различных дисков в ядерное устройство.   <!-- You can attempt to stick more types of disks into the nuke (www.github.com/ParadiseSS13/Paradise/pull/27804) -->
add: Добавлена новая галлюцинация.   <!-- Added a new hallucination (www.github.com/ParadiseSS13/Paradise/pull/27619) -->
add: Добавлены кастомные сообщения галлюцинаций для функции осмотра.   <!-- Added custom hallucination messages to the examine feature (www.github.com/ParadiseSS13/Paradise/pull/27651) -->
add: Добавлен новый вариант «Скалистого Мотеля».   <!-- Added a new variation of the Rocky Motel (www.github.com/ParadiseSS13/Paradise/pull/27577) -->
add: Добавлены галлюцинации, связанные с гранатами.   <!-- Adds grenade-related hallucinations (www.github.com/ParadiseSS13/Paradise/pull/27605) -->
fix: Исправлены спрайты грязных полов.   <!-- Fixed Grimey Flooring (www.github.com/ParadiseSS13/Paradise/pull/27926) -->
add: Добавлена Великая Синтвейв Рубашка для участников Паратоберфеста.   <!-- Added the Great Synthwave Shirt for paratoberfest participants (www.github.com/ParadiseSS13/Paradise/pull/27922) -->
add: Добавлены значки за вклад в программирование, картографирование и создание спрайтов для дополнительных наград/будущих событий. <!-- Added coding, mapping and spriting contribution pins for additional rewards/future events (www.github.com/ParadiseSS13/Paradise/pull/27922) -->
/:cl:
